### PR TITLE
DNF plugin fixes and debugging

### DIFF
--- a/dnf-plugin-nvidia.spec
+++ b/dnf-plugin-nvidia.spec
@@ -1,6 +1,6 @@
 %define pythonX_sitelib	%{?_python_sitelib}%{?!_python_sitelib:/usr/lib/python3.6/site-packages}
 Name:		dnf-plugin-nvidia
-Version:	1.8
+Version:	1.9
 Release:	1%{?dist}
 Summary:	DNF plugin needed to remove old kernel modules
 
@@ -27,6 +27,12 @@ install -m 644 %{SOURCE0} %{buildroot}%{pythonX_sitelib}/dnf-plugins/nvidia.py
 %{pythonX_sitelib}/dnf-plugins/__pycache__/nvidia.*
 
 %changelog
+* Thu Sep 17 2020 Kevin Mittman <kmittman@nvidia.com> 1.9-1
+ - Do not block kernel updates if DKMS stream kmod package is installed
+ - Retrieve k_corepkg hawkey package object rather than string
+ - Expose plugin as DNF command (for debugging)
+ - Print verbose output when running as a command
+
 * Wed Sep 9 2020 Kevin Mittman <kmittman@nvidia.com> 1.8-1
  - Block kernel-core updates that do not have a matching kmod package
 

--- a/nvidia-dnf.py
+++ b/nvidia-dnf.py
@@ -30,6 +30,12 @@ def ver_cmp_pkgs(sack, po1, po2):
     return sack.evr_cmp(str(po1.epoch) + ':' + str(po1.version) + '-' + str(po1.release),
                         str(po2.epoch) + ':' + str(po2.version) + '-' + str(po2.release));
 
+def revive_msg(var, msg, val = ''):
+    if var is not None:
+        print(msg)
+
+    return val
+
 
 class NvidiaPlugin(dnf.Plugin):
     name = 'nvidia'
@@ -68,17 +74,30 @@ class NvidiaPlugin(dnf.Plugin):
         available_kernels = sack.query().available().filter(name = KERNEL_PKG_NAME)
         available_k_cores = sack.query().available().filter(name = KERNEL_PKG_REAL)
 
+        # Print debugging if running from CLI
+        if installed_kernel:
+            revive_msg(debug, '\nkernel: ' + str(installed_kernel))
+
+        if available_kernels:
+            string_kernels = ' '.join([str(elem) for elem in available_kernels])
+            revive_msg(debug, '\navailable ' + KERNEL_PKG_NAME + '(s): ' + str(string_kernels))
+
+        if available_k_cores:
+            string_cores = ' '.join([str(elem) for elem in available_k_cores])
+            revive_msg(debug, '\navailable ' + KERNEL_PKG_REAL + '(s): ' + str(string_cores))
+
+        if installed_modules:
+            string_modules = ' '.join([str(elem) for elem in installed_modules])
+            revive_msg(debug, '\ninstalled kmod(s): ' + str(string_modules))
+
+        # DKMS stream enabled
+        if installed_modules and 'dkms' in string_modules:
+            return
+
         # Installed driver
         try:
             driver = installed_drivers[0]
         except:
-            return
-
-        if installed_modules:
-            string_modules = ' '.join([str(elem) for elem in installed_modules])
-
-        # DKMS stream enabled
-        if installed_modules and 'dkms' in string_modules:
             return
 
         # Exclude all available kernels which are newer than the most recent installed
@@ -141,3 +160,4 @@ class NvidiaPluginCommand(dnf.cli.Command):
     def run(self):
         nvPlugin = NvidiaPlugin(dnf.Base, dnf.cli.Cli)
         nvPlugin.sack(True)
+        print("---")

--- a/nvidia-dnf.py
+++ b/nvidia-dnf.py
@@ -44,6 +44,7 @@ class NvidiaPlugin(dnf.Plugin):
 
         installed_drivers = sack.query().installed().filter(name = DRIVER_PKG_NAME)
         installed_kernel = list(sack.query().installed().filter(name = KERNEL_PKG_NAME))
+        installed_modules = list(sack.query().installed().filter(name__substr = KMOD_PKG_PREFIX))
 
         if not installed_drivers:
             return
@@ -55,6 +56,13 @@ class NvidiaPlugin(dnf.Plugin):
         installed_kernel  = sorted(installed_kernel, reverse = True, key = lambda p: evr_key(p, sack))[0]
         available_kernels = sack.query().available().filter(name = KERNEL_PKG_NAME)
         driver = installed_drivers[0]
+
+        if installed_modules:
+            string_modules = ' '.join([str(elem) for elem in installed_modules])
+
+        # DKMS stream enabled
+        if installed_modules and 'dkms' in string_modules:
+            return
 
         # Exclude all available kernels which are newer than the most recent installed
         # kernel AND do NOT have a kmod package


### PR DESCRIPTION
 - Do not block kernel updates if DKMS stream kmod package is installed
 - Retrieve k_corepkg hawkey package object rather than string
 - Catch errors with try-except blocks
 - Expose plugin as DNF command (for debugging)
 - Print verbose output when running as a command