### PR TITLE
fix NVIDIA/yum-packaging-nvidia-plugin#8

### DIFF
--- a/nvidia-dnf.py
+++ b/nvidia-dnf.py
@@ -128,13 +128,14 @@ class NvidiaPlugin(dnf.Plugin):
                 print('Unable to find matching ' + KERNEL_PKG_REAL + ' package')
 
             # Iterate through drivers in stream
+            kmod_pkg = None
             for a_driver in available_drivers:
                 # Get package name
                 kmod_pkg_name = KMOD_PKG_PREFIX + '-' + str(a_driver.version) + '-' + \
                         str(kernelpkg.version) + '-' + str(remove_release_dist(kernelpkg.release))
 
                 # Append object
-                if 'kmod_pkg' in locals():
+                if kmod_pkg is not None:
                     kmod_pkg = sack.query().available().filter(name = kmod_pkg_name, version = a_driver.version).union(kmod_pkg)
                 else:
                     kmod_pkg = sack.query().available().filter(name = kmod_pkg_name, version = a_driver.version)


### PR DESCRIPTION
test the behaviour with `dnf update --downloadonly`

After this fix, one can see `dnf update --downloadonly --nobest` offer upgrade to 348.20.1 instead.

```
Installing dependencies:
 kernel-core                             x86_64   4.18.0-348.20.1.el8_5                        baseos                    38 M
 kernel-devel                            x86_64   4.18.0-348.23.1.el8_5                        baseos                    20 M
 kernel-modules                          x86_64   4.18.0-348.20.1.el8_5                        baseos                    30 M
Installing weak dependencies:
 kmod-nvidia-510.47.03-4.18.0-348.20.1   x86_64   3:510.47.03-3.el8_5                          cuda-rhel8-x86_64         29 M
Skipping packages with broken dependencies:
 kernel-modules                          x86_64   4.18.0-348.23.1.el8_5                        baseos                    30 M


```