### PR TITLE
Fix missing include of compute-only driver during installed driver selection

### DIFF
--- a/nvidia-dnf.py
+++ b/nvidia-dnf.py
@@ -57,7 +57,7 @@ class NvidiaPlugin(dnf.Plugin):
             sack = self.base.sack
 
         # check installed
-        installed_drivers = sack.query().installed().filter(name = DESKTOP_PKG_NAME)
+        installed_drivers = sack.query().installed().filter(name = [DESKTOP_PKG_NAME, COMPUTE_PKG_NAME])
         installed_kernel = list(sack.query().installed().filter(name = KERNEL_PKG_NAME))
         installed_modules = list(sack.query().installed().filter(name__substr = KMOD_PKG_PREFIX))
 


### PR DESCRIPTION
In case the compute-only driver was installed instead of the full driver, this plugin will not work as it will not properly recognize the compute-only driver during installed driver selection. This commit ensures, that the compute-only driver is also honored during installed driver selection by including the package name for the compute-only driver in the appropriate filter.

fix NVIDIA#13